### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.6.2'
 
+#Fix deployment issue
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 # Use sqlite3 as the database for Active Record


### PR DESCRIPTION
I encountered a deployment error while deploying this repository as part of the Azure app service OSS specialist learning path on [Cloud Academy](cloudacademy.com 'cloudacademy.com'). The error is detailed in the last few lines of the deployment log:

```
Using ruby version 2.6.2
/home/site/wwwroot
Found gemfile
~/site/wwwroot ~/site/repository
Setting ruby version
Running bundle clean
Could not find rake-13.0.1 in any of the sources
Running bundle install
Fetching gem metadata from https://rubygems.org/..........
Your bundle is locked to mimemagic (0.3.5), but that version could not be found
in any of the sources listed in your Gemfile. If you haven't changed sources,
that means the author of mimemagic (0.3.5) has removed it. You'll need to update
your bundle to a version other than mimemagic (0.3.5) that hasn't been removed
in order to install.
An error has occurred during web site deployment.
bundler failed
\n/opt/Kudu/Scripts/starter.sh "/home/site/deployments/tools/deploy.sh"
```

I looked around and discovered a similar problem [here](https://stackoverflow.com/questions/66919504/your-bundle-is-locked-to-mimemagic-0-3-5-but-that-version-could-not-be-found 'StackOverflow'), which appears to be related to some MimeMagic versions being "yanked," i.e. deprecated.

# Fix: 
I forked the repository, followed the recommendation in the above link to add `gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'` to the GemFile, disconnected the deployment source from external git, and deployed to Azure from my forked copy; the deployment was successful this time. As a result, I put together this pull request to update the GemFile.